### PR TITLE
Move Fixes from Other Module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,6 @@ terraform {
       source  = "hashicorp/google-beta"
       version = "~> 4.76"
     }
-
     random = {
       source  = "hashicorp/random"
       version = "3.4.3"
@@ -45,14 +44,16 @@ resource "google_iam_workload_identity_pool_provider" "oidc_provider" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.pool.workload_identity_pool_id
   workload_identity_pool_provider_id = "${google_service_account.service_account.account_id}-provider"
   attribute_mapping = {
-    "google.subject"       = "assertion.sub",
-    "attribute.actor"      = "assertion.actor",
-    "attribute.repository" = "assertion.repository"
+    "google.subject"                = "assertion.sub",
+    "attribute.actor"               = "assertion.actor_id",
+    "attribute.repository"          = "assertion.repository",
+    "attribute.repository_id"       = "assertion.repository_id",
+    "attribute.repository_owner"    = "assetion.repository_owner",
+    "attribute.repository_owner_id" = "assertion.repository_owner_id",
   }
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
-  project = var.project
 }
 
 resource "google_service_account_iam_member" "workload_identity_pool_iam" {


### PR DESCRIPTION
*From previous pr:*

Per Google and Github, I was able to find two pieces of documentation that were important:

* [Configure Workload Identity Federation with deployment pipelines](https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines#mappings-and-conditions)
* [About security hardening with OpenID Connect](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token)

The first document highlights some of the attributes that the Google Cloud conneciton is relying on. I added those attributes and mapped them the way the other attributes were mapped. 

The second document highlights that `assertion.actor` is no longer in the GitHub OIDC token and has been replaced by `assertion.actor_id`. I believe this is the core of the issue, but I wanted to try and make sure to resolve everything while I was here. ~This should be non-breaking~.

(*tagging this as a breaking change since it appears the existing version is, in fact, broken*)
